### PR TITLE
Npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 LabelSelect is a component used for making multiple choices. The modal is a checkbox like html.
 
 ## Example
-<a href="#android" id="android"><img src="./GIF/android.gif" align="left" width="240"/></a>
+<a href="#android" id="android"><img src="http://7xjgb0.com1.z0.glb.clouddn.com/android.gif" align="left" width="240"/></a>
 
-<a href="#ios" id="ios"><img src="./GIF/ios.gif" width="240"/></a>
+<a href="#ios" id="ios"><img src="http://7xjgb0.com1.z0.glb.clouddn.com/ios.gif" width="240"/></a>
 
 ## Usage
 


### PR DESCRIPTION
Import (PropTypes from react) no longer used
The import is now made by its own module.
Change tested in my own app.

In file react-native-label-select\LabelSelect\Index.js
Currently the beginning of import:
**import React, {Component, PropTypes} from 'react';**

But the correct way is now:
**import React, {Component} from 'react';
import PropTypes from 'prop-types';**

Can not push your branch, but it's a good change to consider.




